### PR TITLE
Allow users to add evidence

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,23 @@ app.post('/case', function(request, response) {
   response.sendStatus(200);
 });
 
+app.post('/evidence', function(request, response) {
+  var updateCase = cases.find(function(existingCase) {
+    return existingCase.caseReference === request.body.caseReference;
+  });
+  
+  var evidenceList = null;
+  if(request.body.evidenceOwner === 'landlord') {
+    evidenceList = updateCase.landlordEvidence;
+  } else {
+    evidenceList = updateCase.tenantEvidence;
+  }
+  
+  evidenceList.push(request.body.evidence);
+  
+  response.sendStatus(200);
+});
+
 app.listen(app.get('port'), function() {
   console.log('Node app is running on port', app.get('port'));
 });

--- a/index.js
+++ b/index.js
@@ -25,7 +25,9 @@ var cases = [
     depositAmount: 1000,
     tenantAmount: 800,
     landlordAmount: 700,
-    caseReference: 1
+    caseReference: 1,
+    landlordEvidence: [ "Tenant broke window" ],
+    tenantEvidence: []
   },
   { 
     address: "2 Road Name, Town, City, Post Code", 
@@ -35,7 +37,9 @@ var cases = [
     depositAmount: 2000,
     tenantAmount: 1600,
     landlordAmount: 1400,
-    caseReference: 2
+    caseReference: 2,
+    landlordEvidence: [],
+    tenantEvidence: [ "I left the place as I found it" ]
   },
   { 
     address: "10 Avenue Name, Town, City, Post Code", 
@@ -45,10 +49,24 @@ var cases = [
     depositAmount: 5000,
     tenantAmount: 4000,
     landlordAmount: 1500,
-    caseReference: 3
+    caseReference: 3,
+    landlordEvidence: [],
+    tenantEvidence: []
   },
+  { 
+    address: "5 Lane Name, Town, City, Post Code", 
+    tenancyStartDate: new Date(2015, 3, 19),
+    tenancyEndDate: new Date(2016, 4, 5), 
+    dateAdjudicationEntered: new Date(2016, 7, 25),
+    depositAmount: 200,
+    tenantAmount: 100,
+    landlordAmount: 150,
+    caseReference: 4,
+    landlordEvidence: [ "Tenant didn't clean" ],
+    tenantEvidence: [ "I hired a professional cleaner" ]
+  }
 ];
-var nextCaseReference = 4;
+var nextCaseReference = 5;
 
 app.get('/cases', function(request, response) {
   response.send(cases);
@@ -56,6 +74,9 @@ app.get('/cases', function(request, response) {
 
 app.post('/case', function(request, response) {
   request.body.caseReference = nextCaseReference;
+  request.body.landlordEvidence = [];
+  request.body.tenantEvidence = [];
+  
   nextCaseReference++;
   cases.push(request.body);
   

--- a/src/addEvidence.js
+++ b/src/addEvidence.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import { Button, Modal, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+
+class AddCase extends React.Component {
+    constructor() {
+        super();
+        
+        this.state = {
+            showModal: false,
+            isLandlordEvidence: true,
+            evidence: "",
+            evidenceValidationEnabled: false
+        };
+    }
+    
+    render() {
+        return (
+            <div>
+                <Button bsStyle="primary" onClick={() => this.open()}>Add Evidence</Button>
+                <Modal show={this.state.showModal} onHide={() => this.close()}>
+                    <Modal.Header closeButton>
+                        <Modal.Title>Add evidence</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <FormGroup validationState={this.getEvidenceValidationState()}>
+                            <ControlLabel>Evidence</ControlLabel>
+                            <FormControl type="textarea" 
+                                         onChange={this.handleEvidenceChange.bind(this)}
+                                         onBlur={this.handleEvidenceChange.bind(this)}/>
+                        </FormGroup>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button bsStyle="success" onClick={() => this.addEvidence()}>Add Evidence</Button>
+                        <Button bsStyle="primary" onClick={() => this.close()}>Close</Button>
+                    </Modal.Footer>
+                </Modal>
+            </div>
+        );
+    }
+    
+    /* TODO: Make this validation generic */
+    getEvidenceValidationState() {
+        if(this.state.evidenceValidationEnabled && this.state.evidence.length === 0) {
+            return 'error';    
+        } else {
+            return null;
+        }
+    }
+    
+    handleEvidenceChange(e) {
+        this.setState({ evidence: e.target.value, evidenceValidationEnabled: true });
+    }
+    
+    addEvidence() {
+        // Enable all validation when submitting
+        this.setState({ evidenceValidationEnabled: true }, function() {
+            if(this.getEvidenceValidationState() === null) {
+                this.props.addEvidence({ evidence: this.state.evidence, isLandlordEvidence: this.state.isLandlordEvidence });
+                this.setState({ showModal: false });
+            }
+        });
+    }
+    
+    close() {
+        this.setState({ showModal: false });
+    }
+    
+    open() {
+        this.setState({ 
+            showModal: true, 
+            isLandlordEvidence: true,
+            evidence: "",
+            evidenceValidationEnabled: false,
+        });
+    }
+}
+
+export default AddCase;

--- a/src/addEvidence.js
+++ b/src/addEvidence.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import { Button, Modal, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+import { Button, Modal, FormGroup, FormControl, ControlLabel, Radio } from 'react-bootstrap';
 
 class AddCase extends React.Component {
     constructor() {
@@ -9,7 +9,7 @@ class AddCase extends React.Component {
         
         this.state = {
             showModal: false,
-            isLandlordEvidence: true,
+            evidenceOwner: "landlord",
             evidence: "",
             evidenceValidationEnabled: false
         };
@@ -24,6 +24,19 @@ class AddCase extends React.Component {
                         <Modal.Title>Add evidence</Modal.Title>
                     </Modal.Header>
                     <Modal.Body>
+                        <FormGroup>
+                            <ControlLabel>Whose evidence is it?</ControlLabel>
+                            <Radio value="landlord"
+                                   checked={this.state.evidenceOwner === 'landlord'}
+                                   onChange={this.handleEvidenceOwnerChange.bind(this)}>
+                                Landlord's
+                            </Radio>
+                            <Radio value="tenant"
+                                   checked={this.state.evidenceOwner === 'tenant'}
+                                   onChange={this.handleEvidenceOwnerChange.bind(this)}>
+                                Tenant's
+                            </Radio>
+                        </FormGroup>
                         <FormGroup validationState={this.getEvidenceValidationState()}>
                             <ControlLabel>Evidence</ControlLabel>
                             <FormControl type="textarea" 
@@ -53,11 +66,15 @@ class AddCase extends React.Component {
         this.setState({ evidence: e.target.value, evidenceValidationEnabled: true });
     }
     
+    handleEvidenceOwnerChange(e) {
+        this.setState({ evidenceOwner: e.target.value });
+    }
+    
     addEvidence() {
         // Enable all validation when submitting
         this.setState({ evidenceValidationEnabled: true }, function() {
             if(this.getEvidenceValidationState() === null) {
-                this.props.addEvidence({ evidence: this.state.evidence, isLandlordEvidence: this.state.isLandlordEvidence });
+                this.props.addEvidence({ evidence: this.state.evidence, evidenceOwner: this.state.evidenceOwner });
                 this.setState({ showModal: false });
             }
         });
@@ -70,7 +87,7 @@ class AddCase extends React.Component {
     open() {
         this.setState({ 
             showModal: true, 
-            isLandlordEvidence: true,
+            evidenceOwner: "landlord",
             evidence: "",
             evidenceValidationEnabled: false,
         });

--- a/src/addEvidence.js
+++ b/src/addEvidence.js
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 
 import { Button, Modal, FormGroup, FormControl, ControlLabel, Radio } from 'react-bootstrap';
 
-class AddCase extends React.Component {
+class AddEvidence extends React.Component {
     constructor() {
         super();
         
@@ -94,4 +94,4 @@ class AddCase extends React.Component {
     }
 }
 
-export default AddCase;
+export default AddEvidence;

--- a/src/app.js
+++ b/src/app.js
@@ -24,8 +24,8 @@ class App extends React.Component {
         return (
             <div className="container">
                 <h2>Please review the cases waiting to be assigned</h2>
-                <CaseTable cases={this.state.cases} addEvidence={this.handleAddEvidence}/>
-                <AddCase addCase={this.handleAddCase}/>
+                <CaseTable cases={this.state.cases} addEvidence={this.handleAddEvidence.bind(this)}/>
+                <AddCase addCase={this.handleAddCase.bind(this)}/>
             </div>
         );
     }
@@ -49,20 +49,25 @@ class App extends React.Component {
     }
     
     handleAddEvidence(evidence, caseReference) {
-        
+        evidence.caseReference = caseReference;
+        this.serverPost('evidence', evidence);
     }
     
     handleAddCase(newCase) {
+        this.serverPost('case', newCase);
+    }
+    
+    serverPost(url, jsonContent) {
         var self = this; /* TODO: There must be a better way of handling this */
         
         var headers =  {
           'Accept': 'application/json',
           'Content-Type': 'application/json'
-        }
+        };
         
-        var content = JSON.stringify(newCase)
+        var content = JSON.stringify(jsonContent);
         
-        fetch('case', { method: 'POST', body: content, headers: headers })
+        fetch(url, { method: 'POST', body: content, headers: headers })
             .then(function(response) {
                 self.refreshCaseList();
             });

--- a/src/app.js
+++ b/src/app.js
@@ -24,7 +24,7 @@ class App extends React.Component {
         return (
             <div className="container">
                 <h2>Please review the cases waiting to be assigned</h2>
-                <CaseTable cases={this.state.cases}/>
+                <CaseTable cases={this.state.cases} addEvidence={this.handleAddEvidence}/>
                 <AddCase addCase={this.handleAddCase}/>
             </div>
         );
@@ -46,6 +46,10 @@ class App extends React.Component {
             .catch(function(error) {
                 console.log('Error occurred: ' + error);
             });
+    }
+    
+    handleAddEvidence(evidence, caseReference) {
+        
     }
     
     handleAddCase(newCase) {

--- a/src/caseTable.js
+++ b/src/caseTable.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { render } from 'react-dom';
 import { Table } from 'react-bootstrap'
 
+import AddEvidence from './addEvidence'
+
 function CaseTableRow(props) {
     function displayEvidence(landlordEvidence, tenantEvidence) {
         var landlordHasEvidence = landlordEvidence && landlordEvidence.length > 0;
@@ -23,13 +25,14 @@ function CaseTableRow(props) {
             <td>{props.case.address}</td>
             <td>{props.case.depositAmount}</td>
             <td>{displayEvidence(props.case.landlordEvidence, props.case.tenantEvidence)}</td>
+            <td><AddEvidence addEvidence={props.addEvidence}/></td>
         </tr>
     )
 }
 
 function CaseTable(props) {
     var rows = props.cases.map(function(step) {
-        return (<CaseTableRow case={step} key={step.caseReference} />);
+        return (<CaseTableRow case={step} key={step.caseReference} addEvidence={props.addEvidence}/>);
     });
     
     return (
@@ -39,6 +42,7 @@ function CaseTable(props) {
                     <th>Address</th>
                     <th>Deposit Amount</th>
                     <th>Has Evidence</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>

--- a/src/caseTable.js
+++ b/src/caseTable.js
@@ -25,7 +25,7 @@ function CaseTableRow(props) {
             <td>{props.case.address}</td>
             <td>{props.case.depositAmount}</td>
             <td>{displayEvidence(props.case.landlordEvidence, props.case.tenantEvidence)}</td>
-            <td><AddEvidence addEvidence={props.addEvidence}/></td>
+            <td><AddEvidence addEvidence={(evidence) => props.addEvidence(evidence, props.case.caseReference)}/></td>
         </tr>
     )
 }

--- a/src/caseTable.js
+++ b/src/caseTable.js
@@ -3,10 +3,26 @@ import { render } from 'react-dom';
 import { Table } from 'react-bootstrap'
 
 function CaseTableRow(props) {
+    function displayEvidence(landlordEvidence, tenantEvidence) {
+        var landlordHasEvidence = landlordEvidence && landlordEvidence.length > 0;
+        var tenantHasEvidence = tenantEvidence && tenantEvidence.length > 0;
+        
+        if(!landlordHasEvidence && !tenantHasEvidence) {
+            return "No";
+        } else if(landlordHasEvidence && !tenantHasEvidence) {
+            return "Landlord Only";
+        } else if(!landlordHasEvidence && tenantHasEvidence) {
+            return "Tenant Only";
+        } else {
+            return "Yes";
+        }
+    }
+    
     return (
         <tr>
             <td>{props.case.address}</td>
             <td>{props.case.depositAmount}</td>
+            <td>{displayEvidence(props.case.landlordEvidence, props.case.tenantEvidence)}</td>
         </tr>
     )
 }
@@ -22,6 +38,7 @@ function CaseTable(props) {
                 <tr>
                     <th>Address</th>
                     <th>Deposit Amount</th>
+                    <th>Has Evidence</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Each case now has a button which pops up a modal allowing the user to add evidence.
This evidence is in text form.
The user is provided with radio buttons to select between submitting landlord evidence and tenant evidence.