### PR TITLE
Tidy button positioning

### DIFF
--- a/src/addCase.js
+++ b/src/addCase.js
@@ -19,7 +19,7 @@ class AddCase extends React.Component {
     render() {
         return (
             <div>
-                <Button bsStyle="primary" onClick={() => this.open()} className="pull-right">Add Case</Button>
+                <Button bsStyle="primary" onClick={() => this.open()}>Add Case</Button>
                 <Modal show={this.state.showModal} onHide={() => this.close()}>
                     <Modal.Header closeButton>
                         <Modal.Title>Add a new case</Modal.Title>

--- a/src/app.js
+++ b/src/app.js
@@ -25,7 +25,9 @@ class App extends React.Component {
             <div className="container">
                 <h2>Please review the cases waiting to be assigned</h2>
                 <CaseTable cases={this.state.cases} addEvidence={this.handleAddEvidence.bind(this)}/>
-                <AddCase addCase={this.handleAddCase.bind(this)}/>
+                <div className="pull-right">
+                    <AddCase addCase={this.handleAddCase.bind(this)}/>
+                </div>
             </div>
         );
     }

--- a/src/caseTable.js
+++ b/src/caseTable.js
@@ -25,7 +25,7 @@ function CaseTableRow(props) {
             <td>{props.case.address}</td>
             <td>{props.case.depositAmount}</td>
             <td>{displayEvidence(props.case.landlordEvidence, props.case.tenantEvidence)}</td>
-            <td><AddEvidence addEvidence={(evidence) => props.addEvidence(evidence, props.case.caseReference)}/></td>
+            <td className="text-center"><AddEvidence addEvidence={(evidence) => props.addEvidence(evidence, props.case.caseReference)}/></td>
         </tr>
     )
 }


### PR DESCRIPTION
Centre add evidence buttons.
Move the pull right on the add case button out of the add case button (it shouldn't really position itself as that makes it less encapsulated)