### PR TITLE
Remove race condition on server

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,15 +116,15 @@ function updateCase(caseReference, update, callback) {
     update,
     {},
     (error) => {
+      if (callback) {
+        callback(error); 
+      }
+      
       if (error) {
         return console.log(error);
       }
   
       console.log('updated case ' + caseReference);
-      
-      if (callback) {
-        callback(); 
-      }
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -52,9 +52,9 @@ app.post('/case', function(request, response) {
     request.body.status = 'awaiting evidence';
     
     createCase(request.body);
-  });
   
-  response.sendStatus(200);
+    response.sendStatus(200);
+  });
 });
 
 app.post('/evidence', function(request, response) {
@@ -68,16 +68,16 @@ app.post('/evidence', function(request, response) {
     evidenceList.push(request.body.evidence);
     var evidenceUpdate = { $set: {} };
     evidenceUpdate.$set[evidenceProperty] = evidenceList;
-    updateCase(request.body.caseReference, evidenceUpdate);
+    updateCase(request.body.caseReference, evidenceUpdate, () => {
+      response.sendStatus(200);      
+    });
   });
-  
-  response.sendStatus(200);
 });
 
 app.post('/markForAdjudication', function(request, response) {
-  updateCase(request.body.caseReference, { $set: { status: 'awaiting adjudication' }});
-  
-  response.sendStatus(200);
+  updateCase(request.body.caseReference, { $set: { status: 'awaiting adjudication' }}, () => {
+    response.sendStatus(200);    
+  });
 });
 
 MongoClient.connect(app.get('connectionString'), (err, database) => {
@@ -110,7 +110,7 @@ function createCase(newCase) {
   });
 }
 
-function updateCase(caseReference, update) {
+function updateCase(caseReference, update, callback) {
   db.collection('cases').findOneAndUpdate(
     { caseReference: caseReference },
     update,
@@ -121,6 +121,10 @@ function updateCase(caseReference, update) {
       }
   
       console.log('updated case ' + caseReference);
+      
+      if (callback) {
+        callback(); 
+      }
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -51,9 +51,9 @@ app.post('/case', function(request, response) {
     request.body.tenantEvidence = [];
     request.body.status = 'awaiting evidence';
     
-    createCase(request.body);
-  
-    response.sendStatus(200);
+    createCase(request.body, () => {
+      response.sendStatus(200);      
+    });
   });
 });
 
@@ -100,8 +100,12 @@ function getCases(callback) {
   });
 }
 
-function createCase(newCase) {
+function createCase(newCase, callback) {
   db.collection('cases').save(newCase, (error) => {
+    if (callback) {
+      callback(error); 
+    }
+      
     if (error) {
       return console.log(error);
     }


### PR DESCRIPTION
By having the server respond from posts prior to confirming that the database add had been completed, it was possible for the refresh to occur before the data had been added to the database. This would mean that would make a chance on the site, the site would refresh but no change would display. To fix this we wait for the database change to complete before returning.